### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       id-token: write
     steps:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Restrict the GitHub Actions release workflow contents permission from write to read.